### PR TITLE
I put in test for support of .textContent property. IE 8 does not suppor...

### DIFF
--- a/jquery.deorphan.js
+++ b/jquery.deorphan.js
@@ -36,7 +36,7 @@
 
 		function _deOrphan(node) {
 			$(node).contents().each(function (i,node) {
-				if (node.nodeType == 3) { // nodeType 3 is TEXT_NODE
+				if (node.nodeType == 3 && (typeof(node.textContent) !== 'undefined')) { // nodeType 3 is TEXT_NODE
 					node.textContent = node.nodeValue.replace(/ (\S*)$/, '\u00A0$1');
 				} else {
 					_deOrphan(node);


### PR DESCRIPTION
...t this (but IE 9 does). deOrphan will not work on IE 8 but at least now it will fail gracefully (no crash).
